### PR TITLE
BLD: Add missing <unordered_map> include

### DIFF
--- a/numpy/_core/src/multiarray/unique.cpp
+++ b/numpy/_core/src/multiarray/unique.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstring>
 #include <functional>
+#include <unordered_map>
 #include <unordered_set>
 
 #include <numpy/npy_common.h>


### PR DESCRIPTION
Fixes homebrew builds, see https://github.com/orgs/Homebrew/discussions/6386#discussioncomment-14293523

